### PR TITLE
TW-87415 terraform E-Mail settings: fix optional fields

### DIFF
--- a/teamcity/email.go
+++ b/teamcity/email.go
@@ -62,6 +62,8 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"password": schema.StringAttribute{Optional: true, Sensitive: true},
 			"secure_connection": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("NONE"),
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"NONE", "STARTTLS", "SSL"}...),
 				},

--- a/teamcity/email.go
+++ b/teamcity/email.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-teamcity/client"
@@ -49,14 +50,18 @@ func (r *emailResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 	resp.Schema = schema.Schema{
 		Description: "TeamCity can notify users about various events using email. More info [here](https://www.jetbrains.com/help/teamcity/configuring-notifications.html)",
 		Attributes: map[string]schema.Attribute{
-			"enabled":  schema.BoolAttribute{Required: true},
-			"host":     schema.StringAttribute{Required: true},
-			"port":     schema.Int64Attribute{Required: true},
-			"from":     schema.StringAttribute{Required: true},
-			"login":    schema.StringAttribute{Required: true},
-			"password": schema.StringAttribute{Required: true, Sensitive: true},
+			"enabled": schema.BoolAttribute{Required: true},
+			"host":    schema.StringAttribute{Required: true},
+			"port":    schema.Int64Attribute{Required: true},
+			"from":    schema.StringAttribute{Required: true},
+			"login": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+			"password": schema.StringAttribute{Optional: true, Sensitive: true},
 			"secure_connection": schema.StringAttribute{
-				Required: true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"NONE", "STARTTLS", "SSL"}...),
 				},


### PR DESCRIPTION
Also, TC rest api returns empty string when login is not provided and null for password if it is not provided. This caused the plan to have stateValueNull both for login and password when importing but after applying login state value was not null and this was reported as a bug in provider from terraform side. Now login value defaults to empty string in the state.

This should fix two issues: [1](https://youtrack.jetbrains.com/issue/TW-87415/terraform-E-Mail-settings-password-is-required-while-it-is-not-in-the-UI) and [2](https://youtrack.jetbrains.com/issue/TW-87482/terraform-teamcityemailsettings-forces-update)