### PR TITLE
refactor: Remove unnecessary role global check

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,36 @@
+name: publish
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: get-files-changed
+        id: get-files-changed
+        run: |
+          files="$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})"
+          folders_list="[]"
+          
+          for file in $files
+          do  
+            folder="$(echo $(dirname "${file}") | sed 's!/*\([^/]*\).*!\1!g')"
+            folders_list="$(echo "$folders_list" | jq ". += [\"$folder\"]")"
+          done
+          
+          unique_list="$(echo "$folders_list" | jq -c unique )"
+          echo "::set-output name=FOLDERS_LIST::$unique_list"
+
+      - name: publish
+        uses: seeeverything/publish-terraform-modules@1.0.0
+        with:
+          modules_list: ${{ steps.get-files-changed.outputs.FOLDERS_LIST }}
+          provider: "teamcity"
+          namespace: "jpascal"
+          token: ${{ secrets.TF_CLOUD_API_TOKEN }}
+          recreate: "false"
+          base_version: "1.0.0"
+          autobump: "true"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,9 @@
 name: publish
 
+on:
+  workflow_dispatch:
+
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/teamcity/user.go
+++ b/teamcity/user.go
@@ -109,13 +109,6 @@ func (r *userResource) ValidateConfig(ctx context.Context, req resource.Validate
 				"",
 			)
 		}
-		if !role.Global.ValueBool() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("roles"), //TODO path to specific set item
-				"'global' must be set to 'true'",
-				"",
-			)
-		}
 	}
 }
 


### PR DESCRIPTION
The check for `role.Global.ValueBool()` always being true was unnecessary and has been removed.

```
│ Error: 'global' must be set to 'true'
│ 
│   with teamcity_user.someUser,
│   on users.tf line 9, in resource "teamcity_user" "someUser":
│    9:   roles = [
│   10:     {
│   11:       id      = "PROJECT_LEAD"
│   12:       project = "project1"
│   13:     },
│   14:     {
│   15:       id      = "PROJECT_LEAD"
│   16:       project = "project2"
│   17:     },
│   18:   ]
```
Global can't be set to true always I think...