### PR TITLE
Add support for custom group IDs (keys)

### DIFF
--- a/teamcity/group.go
+++ b/teamcity/group.go
@@ -180,6 +180,11 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	newState := r.readState(actual)
 
+	// Only set the key if it was explicitly set before
+	if oldState.Key.IsNull() {
+		newState.Key = types.StringNull()
+	}
+
 	diags = resp.State.Set(ctx, newState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -264,6 +269,11 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	newState := r.readState(actual)
+
+	// Only set the key if it was explicitly set before
+	if oldState.Key.IsNull() {
+		newState.Key = types.StringNull()
+	}
 
 	diags = resp.State.Set(ctx, newState)
 	resp.Diagnostics.Append(diags...)

--- a/teamcity/group.go
+++ b/teamcity/group.go
@@ -46,13 +46,14 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+				Description: "Deprecated. Use key instead, id is generated on creation and is read only.",
 			},
 			"key": schema.StringAttribute{
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				Description: "Custom key for the group. If not provided, TeamCity will generate one based on the name.",
+				Description: "Custom key (id) for the group. If not provided, TeamCity will generate one based on the name.",
 			},
 			"name": schema.StringAttribute{
 				Required: true,


### PR DESCRIPTION
This change adds the ability to specify custom IDs (keys) for TeamCity groups during creation. The TeamCity API already supports this feature, but the provider didn't expose it.

Changes:
- Add `key` attribute to the group resource schema
- Pass the custom key to the client API when creating groups
- Update documentation to describe the new attribute
- Preserve backward compatibility with existing resources