### PR TITLE
Add role assignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ terraform.tfvars
 .terraform/
 
 swagger.json
+
+.DS_Store

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module terraform-provider-teamcity
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.24.4
 
 require (
 	github.com/google/uuid v1.3.1

--- a/teamcity/group_data.go
+++ b/teamcity/group_data.go
@@ -1,0 +1,195 @@
+package teamcity
+
+import (
+	"context"
+	"terraform-provider-teamcity/client"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ datasource.DataSource              = &groupDataSource{}
+	_ datasource.DataSourceWithConfigure = &groupDataSource{}
+)
+
+type groupDataSource struct {
+	client *client.Client
+}
+
+func NewGroupDataSource() datasource.DataSource {
+	return &groupDataSource{}
+}
+
+func (d *groupDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_group"
+}
+
+type groupDataSourceModel struct {
+	Id           types.String     `tfsdk:"id"`
+	Key          types.String     `tfsdk:"key"`
+	Name         types.String     `tfsdk:"name"`
+	Roles        []roleAssignment `tfsdk:"roles"`
+	ParentGroups types.Set        `tfsdk:"parent_groups"`
+}
+
+func (d *groupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to get information about an existing TeamCity group.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The internal ID of the group.",
+			},
+			"key": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The key (identifier) of the group to retrieve. Either key or name must be specified.",
+			},
+			"name": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The name of the group to retrieve. Either key or name must be specified.",
+			},
+			"roles": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The role ID.",
+						},
+						"global": schema.BoolAttribute{
+							Computed:    true,
+							Description: "Whether the role is assigned globally.",
+						},
+						"project": schema.StringAttribute{
+							Computed:    true,
+							Description: "The project ID if the role is project-specific.",
+						},
+					},
+				},
+				Description: "List of roles assigned to the group.",
+			},
+			"parent_groups": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+				Description: "Set of parent group keys.",
+			},
+		},
+	}
+}
+
+func (d *groupDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.client = req.ProviderData.(*client.Client)
+}
+
+func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config groupDataSourceModel
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that either key or name is specified
+	if config.Key.IsNull() && config.Name.IsNull() {
+		resp.Diagnostics.AddError(
+			"Invalid configuration",
+			"Either 'key' or 'name' must be specified",
+		)
+		return
+	}
+
+	// If both are specified, prefer key
+	if !config.Key.IsNull() && !config.Name.IsNull() {
+		resp.Diagnostics.AddWarning(
+			"Both key and name specified",
+			"Both 'key' and 'name' were specified. Using 'key' for the lookup.",
+		)
+	}
+
+	var group *client.Group
+	var err error
+
+	// Get group by key or name
+	if !config.Key.IsNull() {
+		// Get by key
+		group, err = d.client.GetGroup(config.Key.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading group by key",
+				err.Error(),
+			)
+			return
+		}
+	} else if !config.Name.IsNull() {
+		// Get by name - this requires GetGroupByName method in client
+		// If the client doesn't have this method, we might need to get all groups and filter
+		group, err = d.client.GetGroupByName(config.Name.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading group by name",
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	if group == nil {
+		identifier := config.Key.ValueString()
+		if config.Key.IsNull() {
+			identifier = "name '" + config.Name.ValueString() + "'"
+		} else {
+			identifier = "key '" + identifier + "'"
+		}
+		resp.Diagnostics.AddError(
+			"Group not found",
+			"The group with "+identifier+" was not found",
+		)
+		return
+	}
+
+	// Map response to model
+	state := groupDataSourceModel{
+		Id:   types.StringValue(group.Key),
+		Key:  types.StringValue(group.Key),
+		Name: types.StringValue(group.Name),
+	}
+
+	// Map roles
+	if group.Roles != nil && len(group.Roles.RoleAssignment) > 0 {
+		state.Roles = []roleAssignment{}
+		for _, role := range group.Roles.RoleAssignment {
+			assignment := roleAssignment{
+				Id: types.StringValue(role.Id),
+			}
+			if role.Scope == "g" {
+				assignment.Global = types.BoolValue(true)
+			} else {
+				assignment.Global = types.BoolValue(false)
+				assignment.Project = types.StringValue(role.Scope[2:])
+			}
+			state.Roles = append(state.Roles, assignment)
+		}
+	}
+
+	// Map parent groups
+	if group.Parents != nil && len(group.Parents.Group) > 0 {
+		var parentKeys []attr.Value
+		for _, parent := range group.Parents.Group {
+			parentKeys = append(parentKeys, types.StringValue(parent.Key))
+		}
+		state.ParentGroups, _ = types.SetValue(types.StringType, parentKeys)
+	} else {
+		state.ParentGroups = types.SetNull(types.StringType)
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}

--- a/teamcity/group_role_assignment.go
+++ b/teamcity/group_role_assignment.go
@@ -1,0 +1,214 @@
+package teamcity
+
+import (
+	"context"
+	"fmt"
+	_ "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
+	"terraform-provider-teamcity/client"
+)
+
+var (
+	_ resource.Resource                = &groupRoleAssignmentResource{}
+	_ resource.ResourceWithConfigure   = &groupRoleAssignmentResource{}
+	_ resource.ResourceWithImportState = &groupRoleAssignmentResource{}
+)
+
+type groupRoleAssignmentResource struct {
+	client *client.Client
+}
+
+func NewGroupRoleAssignmentResource() resource.Resource {
+	return &groupRoleAssignmentResource{}
+}
+
+func (r *groupRoleAssignmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_group_role_assignment"
+}
+
+type groupRoleAssignmentResourceModel struct {
+	Id      types.String `tfsdk:"id"`
+	GroupId types.String `tfsdk:"group_id"`
+	RoleId  types.String `tfsdk:"role_id"`
+	Scope   types.String `tfsdk:"scope"`
+}
+
+func (r *groupRoleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages role assignments for TeamCity groups. This resource allows you to assign roles to groups either globally or for specific projects.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The ID of the role assignment (computed).",
+			},
+			"group_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The ID or key of the group to assign the role to.",
+			},
+			"role_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The ID of the role to assign.",
+			},
+			"scope": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The scope of the role assignment. Use 'g' for global scope or 'p:PROJECT_ID' for project-specific scope. Defaults to global if not specified.",
+			},
+		},
+	}
+}
+
+func (r *groupRoleAssignmentResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.client = req.ProviderData.(*client.Client)
+}
+
+func (r *groupRoleAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan groupRoleAssignmentResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Determine scope
+	scope := "g" // default to global
+	if !plan.Scope.IsNull() {
+		scope = plan.Scope.ValueString()
+	}
+
+	// Add role to group
+	err := r.client.AddGroupRole(plan.GroupId.ValueString(), plan.RoleId.ValueString(), scope)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error assigning role to group",
+			err.Error(),
+		)
+		return
+	}
+
+	// Set state
+	state := groupRoleAssignmentResourceModel{
+		Id:      types.StringValue(fmt.Sprintf("%s_%s_%s", plan.GroupId.ValueString(), plan.RoleId.ValueString(), scope)),
+		GroupId: plan.GroupId,
+		RoleId:  plan.RoleId,
+		Scope:   types.StringValue(scope),
+	}
+
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *groupRoleAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state groupRoleAssignmentResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get group to verify role assignment still exists
+	group, err := r.client.GetGroup(state.GroupId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading group",
+			err.Error(),
+		)
+		return
+	}
+
+	if group == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Check if role assignment still exists
+	found := false
+	if group.Roles != nil {
+		for _, role := range group.Roles.RoleAssignment {
+			if role.Id == state.RoleId.ValueString() && role.Scope == state.Scope.ValueString() {
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Role assignment exists, keep current state
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *groupRoleAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This resource doesn't support updates - all attributes have RequiresReplace
+	// The framework will handle this by destroying and recreating the resource
+	resp.Diagnostics.AddError(
+		"Update not supported",
+		"This resource does not support updates. All changes require resource replacement.",
+	)
+}
+
+func (r *groupRoleAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state groupRoleAssignmentResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Remove role from group
+	err := r.client.RemoveGroupRole(state.GroupId.ValueString(), state.RoleId.ValueString(), state.Scope.ValueString())
+	if err != nil {
+		// Check if it's a 404 error (already deleted)
+		if !strings.Contains(err.Error(), "404") {
+			resp.Diagnostics.AddError(
+				"Error removing role from group",
+				err.Error(),
+			)
+		}
+	}
+}
+
+func (r *groupRoleAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import ID format: group_id/role_id/scope
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Import ID must be in the format: group_id/role_id/scope",
+		)
+		return
+	}
+
+	state := groupRoleAssignmentResourceModel{
+		Id:      types.StringValue(fmt.Sprintf("%s_%s_%s", parts[0], parts[1], parts[2])),
+		GroupId: types.StringValue(parts[0]),
+		RoleId:  types.StringValue(parts[1]),
+		Scope:   types.StringValue(parts[2]),
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}

--- a/teamcity/provider.go
+++ b/teamcity/provider.go
@@ -172,6 +172,8 @@ func (p *teamcityProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewBuildConfDataSource,
 		NewPoolDataSource,
 		NewSshKeyDataSource,
+		NewGroupDataSource,
+		NewUserDataSource,
 	}
 }
 
@@ -195,5 +197,7 @@ func (p *teamcityProvider) Resources(_ context.Context) []func() resource.Resour
 		NewLicenseResource,
 		NewParamResource,
 		NewConnectionResource,
+		NewGroupRoleAssignmentResource,
+		NewUserRoleAssignmentResource,
 	}
 }

--- a/teamcity/user_data.go
+++ b/teamcity/user_data.go
@@ -1,0 +1,170 @@
+package teamcity
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strconv"
+	"terraform-provider-teamcity/client"
+)
+
+var (
+	_ datasource.DataSource              = &userDataSource{}
+	_ datasource.DataSourceWithConfigure = &userDataSource{}
+)
+
+type userDataSource struct {
+	client *client.Client
+}
+
+func NewUserDataSource() datasource.DataSource {
+	return &userDataSource{}
+}
+
+func (d *userDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user"
+}
+
+type userDataSourceModel struct {
+	Id       types.String     `tfsdk:"id"`
+	Username types.String     `tfsdk:"username"`
+	Github   types.String     `tfsdk:"github_username"`
+	Roles    []roleAssignment `tfsdk:"roles"`
+}
+
+func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to get information about an existing TeamCity user.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The internal ID of the user. Either id or username must be specified.",
+			},
+			"username": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The username of the user. Either id or username must be specified.",
+			},
+			"github_username": schema.StringAttribute{
+				Computed:    true,
+				Description: "The GitHub username associated with the user.",
+			},
+			"roles": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The role ID.",
+						},
+						"global": schema.BoolAttribute{
+							Computed:    true,
+							Description: "Whether the role is assigned globally.",
+						},
+						"project": schema.StringAttribute{
+							Computed:    true,
+							Description: "The project ID if the role is project-specific.",
+						},
+					},
+				},
+				Description: "List of roles assigned to the user.",
+			},
+		},
+	}
+}
+
+func (d *userDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.client = req.ProviderData.(*client.Client)
+}
+
+func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config userDataSourceModel
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that either id or username is specified
+	if config.Id.IsNull() && config.Username.IsNull() {
+		resp.Diagnostics.AddError(
+			"Invalid configuration",
+			"Either 'id' or 'username' must be specified",
+		)
+		return
+	}
+
+	var user *client.User
+	var err error
+
+	// Get user by id or username
+	if !config.Id.IsNull() {
+		user, err = d.client.GetUser(config.Id.ValueString())
+	} else {
+		user, err = d.client.GetUserByName(config.Username.ValueString())
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading user",
+			err.Error(),
+		)
+		return
+	}
+
+	if user == nil {
+		identifier := config.Id.ValueString()
+		if config.Id.IsNull() {
+			identifier = config.Username.ValueString()
+		}
+		resp.Diagnostics.AddError(
+			"User not found",
+			"The user '"+identifier+"' was not found",
+		)
+		return
+	}
+
+	// Map response to model
+	state := userDataSourceModel{
+		Id:       types.StringValue(strconv.FormatInt(*user.Id, 10)),
+		Username: types.StringValue(user.Username),
+	}
+
+	// Extract GitHub username from properties
+	if user.Properties != nil {
+		for _, p := range user.Properties.Property {
+			if p.Name == "plugin:auth:GitHubApp-oauth:userName" {
+				state.Github = types.StringValue(p.Value)
+				break
+			}
+		}
+	}
+	if state.Github.IsNull() {
+		state.Github = types.StringNull()
+	}
+
+	// Map roles
+	if user.Roles != nil && len(user.Roles.RoleAssignment) > 0 {
+		state.Roles = []roleAssignment{}
+		for _, role := range user.Roles.RoleAssignment {
+			assignment := roleAssignment{
+				Id: types.StringValue(role.Id),
+			}
+			if role.Scope == "g" {
+				assignment.Global = types.BoolValue(true)
+			} else {
+				assignment.Global = types.BoolValue(false)
+				assignment.Project = types.StringValue(role.Scope[2:])
+			}
+			state.Roles = append(state.Roles, assignment)
+		}
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}

--- a/teamcity/user_role_assignment.go
+++ b/teamcity/user_role_assignment.go
@@ -1,0 +1,377 @@
+package teamcity
+
+import (
+	"context"
+	"fmt"
+	_ "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strconv"
+	"strings"
+	"terraform-provider-teamcity/client"
+)
+
+var (
+	_ resource.Resource                = &userRoleAssignmentResource{}
+	_ resource.ResourceWithConfigure   = &userRoleAssignmentResource{}
+	_ resource.ResourceWithImportState = &userRoleAssignmentResource{}
+)
+
+type userRoleAssignmentResource struct {
+	client *client.Client
+}
+
+func NewUserRoleAssignmentResource() resource.Resource {
+	return &userRoleAssignmentResource{}
+}
+
+func (r *userRoleAssignmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user_role_assignment"
+}
+
+type userRoleAssignmentResourceModel struct {
+	Id       types.String `tfsdk:"id"`
+	UserId   types.String `tfsdk:"user_id"`
+	Username types.String `tfsdk:"username"`
+	RoleId   types.String `tfsdk:"role_id"`
+	Scope    types.String `tfsdk:"scope"`
+}
+
+func (r *userRoleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages role assignments for TeamCity users. This resource allows you to assign roles to users either globally or for specific projects.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The ID of the role assignment (computed).",
+			},
+			"user_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "The ID of the user to assign the role to. Either user_id or username must be specified.",
+			},
+			"username": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The username of the user to assign the role to. Either user_id or username must be specified.",
+			},
+			"role_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The ID of the role to assign.",
+			},
+			"scope": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "The scope of the role assignment. Use 'g' for global scope or 'p:PROJECT_ID' for project-specific scope. Defaults to global if not specified.",
+			},
+		},
+	}
+}
+
+func (r *userRoleAssignmentResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.client = req.ProviderData.(*client.Client)
+}
+
+func (r *userRoleAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan userRoleAssignmentResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that either user_id or username is specified
+	if plan.UserId.IsNull() && plan.Username.IsNull() {
+		resp.Diagnostics.AddError(
+			"Invalid configuration",
+			"Either 'user_id' or 'username' must be specified",
+		)
+		return
+	}
+
+	// Get user to obtain ID if username was provided
+	var user *client.User
+	var err error
+	var userId string
+
+	if !plan.Username.IsNull() {
+		user, err = r.client.GetUserByName(plan.Username.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error getting user",
+				err.Error(),
+			)
+			return
+		}
+		if user == nil {
+			resp.Diagnostics.AddError(
+				"User not found",
+				"User with username '"+plan.Username.ValueString()+"' not found",
+			)
+			return
+		}
+		userId = strconv.FormatInt(*user.Id, 10)
+	} else {
+		userId = plan.UserId.ValueString()
+		// Verify user exists
+		user, err = r.client.GetUser(userId)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error getting user",
+				err.Error(),
+			)
+			return
+		}
+		if user == nil {
+			resp.Diagnostics.AddError(
+				"User not found",
+				"User with ID '"+userId+"' not found",
+			)
+			return
+		}
+	}
+
+	// Determine scope
+	scope := "g" // default to global
+	if !plan.Scope.IsNull() {
+		scope = plan.Scope.ValueString()
+	}
+
+	// Build updated user with new role
+	updatedUser := client.User{
+		Id:       user.Id,
+		Username: user.Username,
+	}
+
+	// Copy existing roles and add new one
+	updatedUser.Roles = &client.RoleAssignments{
+		RoleAssignment: []client.RoleAssignment{},
+	}
+
+	// Copy existing roles
+	if user.Roles != nil {
+		for _, role := range user.Roles.RoleAssignment {
+			updatedUser.Roles.RoleAssignment = append(updatedUser.Roles.RoleAssignment, role)
+		}
+	}
+
+	// Add new role
+	updatedUser.Roles.RoleAssignment = append(updatedUser.Roles.RoleAssignment, client.RoleAssignment{
+		Id:    plan.RoleId.ValueString(),
+		Scope: scope,
+	})
+
+	// Update user
+	_, err = r.client.SetUser(updatedUser)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error assigning role to user",
+			err.Error(),
+		)
+		return
+	}
+
+	// Set state
+	state := userRoleAssignmentResourceModel{
+		Id:       types.StringValue(fmt.Sprintf("%s_%s_%s", userId, plan.RoleId.ValueString(), scope)),
+		UserId:   types.StringValue(userId),
+		Username: types.StringValue(user.Username),
+		RoleId:   plan.RoleId,
+		Scope:    types.StringValue(scope),
+	}
+
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *userRoleAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state userRoleAssignmentResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get user to verify role assignment still exists
+	user, err := r.client.GetUser(state.UserId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading user",
+			err.Error(),
+		)
+		return
+	}
+
+	if user == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Update username in case it changed
+	state.Username = types.StringValue(user.Username)
+
+	// Check if role assignment still exists
+	found := false
+	if user.Roles != nil {
+		for _, role := range user.Roles.RoleAssignment {
+			if role.Id == state.RoleId.ValueString() && role.Scope == state.Scope.ValueString() {
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Role assignment exists, update state
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *userRoleAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This resource doesn't support updates - all attributes have RequiresReplace
+	// The framework will handle this by destroying and recreating the resource
+	resp.Diagnostics.AddError(
+		"Update not supported",
+		"This resource does not support updates. All changes require resource replacement.",
+	)
+}
+
+func (r *userRoleAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state userRoleAssignmentResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get current user
+	user, err := r.client.GetUser(state.UserId.ValueString())
+	if err != nil {
+		// If user doesn't exist, consider it deleted
+		if strings.Contains(err.Error(), "404") {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error getting user",
+			err.Error(),
+		)
+		return
+	}
+
+	if user == nil {
+		// User doesn't exist, nothing to delete
+		return
+	}
+
+	// Build updated user without the role
+	updatedUser := client.User{
+		Id:       user.Id,
+		Username: user.Username,
+	}
+
+	updatedUser.Roles = &client.RoleAssignments{
+		RoleAssignment: []client.RoleAssignment{},
+	}
+
+	// Copy existing roles except the one being deleted
+	if user.Roles != nil {
+		for _, role := range user.Roles.RoleAssignment {
+			if !(role.Id == state.RoleId.ValueString() && role.Scope == state.Scope.ValueString()) {
+				updatedUser.Roles.RoleAssignment = append(updatedUser.Roles.RoleAssignment, role)
+			}
+		}
+	}
+
+	// Update user
+	_, err = r.client.SetUser(updatedUser)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error removing role from user",
+			err.Error(),
+		)
+	}
+}
+
+func (r *userRoleAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import ID format: user_id/role_id/scope or username/role_id/scope
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Import ID must be in the format: user_id/role_id/scope or username/role_id/scope",
+		)
+		return
+	}
+
+	// Try to determine if first part is user_id or username
+	var userId string
+	var username string
+
+	// Check if it's a numeric ID
+	if _, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
+		// It's a user ID
+		userId = parts[0]
+		// Get username
+		user, err := r.client.GetUser(userId)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error getting user",
+				err.Error(),
+			)
+			return
+		}
+		if user != nil {
+			username = user.Username
+		}
+	} else {
+		// It's a username
+		username = parts[0]
+		// Get user ID
+		user, err := r.client.GetUserByName(username)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error getting user",
+				err.Error(),
+			)
+			return
+		}
+		if user != nil {
+			userId = strconv.FormatInt(*user.Id, 10)
+		}
+	}
+
+	state := userRoleAssignmentResourceModel{
+		Id:       types.StringValue(fmt.Sprintf("%s_%s_%s", userId, parts[1], parts[2])),
+		UserId:   types.StringValue(userId),
+		Username: types.StringValue(username),
+		RoleId:   types.StringValue(parts[1]),
+		Scope:    types.StringValue(parts[2]),
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}


### PR DESCRIPTION
## Add group and user role management capabilities

The main motivation is that now we should manually create groups and users for role assignments. This approach is inconvenient when using auth via Hub.

This PR introduces significant new functionality for managing TeamCity groups and users through Terraform, including:

### New Data Sources
- **`teamcity_group`** - Retrieve existing group information by key or name
- **`teamcity_user`** - Retrieve existing user information by ID or username

### New Resources
- **`teamcity_group_role_assignment`** - Manage role assignments for groups
- **`teamcity_user_role_assignment`** - Manage role assignments for users

### Key Features
- Support for both global and project-scoped role assignments
- Flexible user lookup by either numeric ID or username
- Group lookup by key or name
- Full import support for existing role assignments
- Proper state management and drift detection

### Implementation Details
- Added `GetGroupByName()` method to the client for name-based group lookups
- Both resources follow Terraform best practices with proper RequiresReplace plan modifiers
- Comprehensive error handling for missing users/groups
- Import format: `{user_id|username|group_id}/role_id/scope`

### Example Usage
```hcl
# Assign a role to a group globally
resource "teamcity_group_role_assignment" "example" {
  group_id = "developers"
  role_id  = "PROJECT_ADMIN"
  scope    = "g"  # global scope
}

# Assign a role to a user for a specific project
resource "teamcity_user_role_assignment" "example" {
  username = "john.doe"
  role_id  = "PROJECT_DEVELOPER"
  scope    = "p:MyProject"  # project scope
}
```

This enhancement significantly improves the provider's capability to manage TeamCity's permission model through Infrastructure as Code.