### PR TITLE
Skip virtual projects when reading agent pool membership

### DIFF
--- a/client/pool.go
+++ b/client/pool.go
@@ -29,7 +29,14 @@ func (c *Client) GetPool(name string) (*models.PoolJson, error) {
 	var pool models.PoolJson
 	endpoint := fmt.Sprintf("/agentPools/name:%s", name)
 
-	err := c.GetRequest(endpoint, "", &pool)
+	// Explicitly request the projects' "virtual" attribute, which is not part of
+	// the default field set. Virtual projects are auto-generated (e.g. by the
+	// parallel tests feature) and assigned to the pool by parent-project
+	// inheritance, so they must be distinguishable from user-managed projects.
+	// The scalar pool fields have to be re-listed or they would be dropped.
+	query := "fields=id,name,maxAgents,projects(project(id,name,virtual))"
+
+	err := c.GetRequest(endpoint, query, &pool)
 
 	if errors.Is(err, ErrNotFound) {
 		return nil, nil

--- a/client/pool.go
+++ b/client/pool.go
@@ -9,6 +9,8 @@ import (
 	"terraform-provider-teamcity/models"
 )
 
+const poolFieldsQuery = "fields=id,name,maxAgents,projects(project(id,name,virtual))"
+
 func (c *Client) NewPool(p models.PoolJson) (*models.PoolJson, error) {
 	var actual models.PoolJson
 
@@ -34,9 +36,7 @@ func (c *Client) GetPool(name string) (*models.PoolJson, error) {
 	// parallel tests feature) and assigned to the pool by parent-project
 	// inheritance, so they must be distinguishable from user-managed projects.
 	// The scalar pool fields have to be re-listed or they would be dropped.
-	query := "fields=id,name,maxAgents,projects(project(id,name,virtual))"
-
-	err := c.GetRequest(endpoint, query, &pool)
+	err := c.GetRequest(endpoint, poolFieldsQuery, &pool)
 
 	if errors.Is(err, ErrNotFound) {
 		return nil, nil

--- a/client/pool_test.go
+++ b/client/pool_test.go
@@ -14,15 +14,18 @@ func TestPool(t *testing.T) {
 		test func(*testing.T)
 	}{
 		{
-			name: "test-get-pool",
+			name: "test-get-pool-requests-virtual-project-fields",
 			test: func(t *testing.T) {
-				testPoolJSON := `{"name":"Default","id":1,"maxAgents":0}`
+				testPoolJSON := `{"name":"Default","id":1,"projects":{"project":[{"name":"Managed","id":"Managed_A"},{"name":"Virtual","id":"Virtual_Project","virtual":true}]}}`
 
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
-					w.Write([]byte(testPoolJSON))
+					_, _ = w.Write([]byte(testPoolJSON))
 					if r.URL.Path != "/app/rest/agentPools/name:Default" {
-						t.Fatal(fmt.Errorf("wrong url: %s", r.URL.Path))
+						t.Fatal(fmt.Errorf("wrong url path: %s", r.URL.Path))
+					}
+					if r.URL.RawQuery != poolFieldsQuery {
+						t.Fatal(fmt.Errorf("wrong query: %s, expected: %s", r.URL.RawQuery, poolFieldsQuery))
 					}
 				}))
 				defer server.Close()

--- a/models/project.go
+++ b/models/project.go
@@ -11,6 +11,7 @@ type ProjectsJson struct {
 type ProjectJson struct {
 	Name            string               `json:"name"`
 	Id              *string              `json:"id,omitempty"`
+	Virtual         bool                 `json:"virtual,omitempty"`
 	ParentProject   *ProjectJson         `json:"parentProject,omitempty"`
 	ProjectFeatures *ProjectFeaturesJson `json:"projectFeatures,omitempty"`
 }

--- a/teamcity/pool_data_source.go
+++ b/teamcity/pool_data_source.go
@@ -115,6 +115,11 @@ func (d *poolDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if pool.Projects != nil {
 		elements := []attr.Value{}
 		for _, project := range pool.Projects.Project {
+			// Skip virtual projects (auto-generated, inherited from parent
+			// projects) so the data source reports only user-managed projects.
+			if project.Virtual {
+				continue
+			}
 			elements = append(elements, types.StringValue(*project.Id))
 		}
 

--- a/teamcity/pool_data_source.go
+++ b/teamcity/pool_data_source.go
@@ -8,7 +8,6 @@ import (
 	"terraform-provider-teamcity/client"
 	"terraform-provider-teamcity/models"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -113,17 +112,7 @@ func (d *poolDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if pool.Projects != nil {
-		elements := []attr.Value{}
-		for _, project := range pool.Projects.Project {
-			// Skip virtual projects (auto-generated, inherited from parent
-			// projects) so the data source reports only user-managed projects.
-			if project.Virtual {
-				continue
-			}
-			elements = append(elements, types.StringValue(*project.Id))
-		}
-
-		state.Projects, diags = types.SetValue(types.StringType, elements)
+		state.Projects, diags = types.SetValue(types.StringType, getProjectsAttrValue(pool.Projects.Project))
 		if diags.HasError() {
 			return
 		}

--- a/teamcity/pool_project_values.go
+++ b/teamcity/pool_project_values.go
@@ -1,0 +1,23 @@
+package teamcity
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"terraform-provider-teamcity/models"
+)
+
+// getProjectsAttrValue converts TeamCity pool members into Terraform set values.
+// Virtual projects are auto-generated and inherited into pools, so they must not
+// enter Terraform state or they will cause perpetual drift. Projects without an
+// ID are skipped defensively as they cannot be represented in provider state.
+func getProjectsAttrValue(data []models.ProjectJson) []attr.Value {
+	projects := []attr.Value{}
+	for _, p := range data {
+		if p.Virtual || p.Id == nil {
+			continue
+		}
+		projects = append(projects, types.StringValue(*p.Id))
+	}
+
+	return projects
+}

--- a/teamcity/pool_resource.go
+++ b/teamcity/pool_resource.go
@@ -370,22 +370,6 @@ func (r *poolResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 }
 
-func getProjectsAttrValue(data []models.ProjectJson) []attr.Value {
-	projects := []attr.Value{}
-	for _, p := range data {
-		// Skip virtual projects: these are auto-generated (e.g. by the parallel
-		// tests feature) and assigned to the pool by parent-project inheritance,
-		// not by the user. Tracking them in state causes perpetual drift since
-		// they are not part of the managed configuration.
-		if p.Virtual {
-			continue
-		}
-		projects = append(projects, types.StringValue(*p.Id))
-	}
-
-	return projects
-}
-
 // configure client
 func (r *poolResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {

--- a/teamcity/pool_resource.go
+++ b/teamcity/pool_resource.go
@@ -373,6 +373,13 @@ func (r *poolResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 func getProjectsAttrValue(data []models.ProjectJson) []attr.Value {
 	projects := []attr.Value{}
 	for _, p := range data {
+		// Skip virtual projects: these are auto-generated (e.g. by the parallel
+		// tests feature) and assigned to the pool by parent-project inheritance,
+		// not by the user. Tracking them in state causes perpetual drift since
+		// they are not part of the managed configuration.
+		if p.Virtual {
+			continue
+		}
 		projects = append(projects, types.StringValue(*p.Id))
 	}
 

--- a/teamcity/pool_unit_test.go
+++ b/teamcity/pool_unit_test.go
@@ -1,0 +1,35 @@
+package teamcity
+
+import (
+	"terraform-provider-teamcity/models"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+
+// getProjectsAttrValue must drop virtual projects (auto-generated, inherited
+// from a parent project) so they never enter Terraform state and cause drift.
+func TestGetProjectsAttrValue_SkipsVirtual(t *testing.T) {
+	data := []models.ProjectJson{
+		{Name: "managed-a", Id: strPtr("Managed_A")},
+		{Name: "auto-generated", Id: strPtr("Gradle_Master_Check_Quick_2_bucket1_virtual"), Virtual: true},
+		{Name: "managed-b", Id: strPtr("Managed_B")},
+		{Name: "auto-generated-stage", Id: strPtr("Gradle_Release7x_Check_Stage_PullRequestFeedback_X"), Virtual: true},
+	}
+
+	got := getProjectsAttrValue(data)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 non-virtual projects, got %d: %v", len(got), got)
+	}
+
+	want := map[string]bool{
+		`"Managed_A"`: true,
+		`"Managed_B"`: true,
+	}
+	for _, v := range got {
+		if !want[v.String()] {
+			t.Errorf("unexpected project in result: %s", v.String())
+		}
+	}
+}

--- a/teamcity/pool_virtual_acceptance_test.go
+++ b/teamcity/pool_virtual_acceptance_test.go
@@ -1,0 +1,243 @@
+package teamcity
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"terraform-provider-teamcity/models"
+)
+
+const testPoolFieldsQuery = "fields=id,name,maxAgents,projects(project(id,name,virtual))"
+
+type fakePoolServerState struct {
+	mu              sync.Mutex
+	poolID          int64
+	poolName        string
+	managedProjects []string
+	virtualProjects []string
+}
+
+func newFakePoolServer(t *testing.T, poolName string, managedProjects, virtualProjects []string) *httptest.Server {
+	t.Helper()
+
+	state := &fakePoolServerState{
+		poolID:          1,
+		poolName:        poolName,
+		managedProjects: append([]string{}, managedProjects...),
+		virtualProjects: append([]string{}, virtualProjects...),
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/app/rest":
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+			return
+		case r.Method == http.MethodPost && r.URL.Path == "/app/rest/agentPools":
+			var req models.PoolJson
+			if err := decodeJSONBody(r, &req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			state.mu.Lock()
+			state.poolName = req.Name
+			state.mu.Unlock()
+
+			writeJSON(w, models.PoolJson{Name: req.Name, Id: &state.poolID, Size: req.Size})
+			return
+		case r.Method == http.MethodPut && r.URL.Path == fmt.Sprintf("/app/rest/agentPools/name:%s/projects", state.poolName):
+			var req models.ProjectsJson
+			if err := decodeJSONBody(r, &req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			managed := make([]string, 0, len(req.Project))
+			for _, project := range req.Project {
+				if project.Id != nil {
+					managed = append(managed, *project.Id)
+				}
+			}
+
+			state.mu.Lock()
+			state.managedProjects = managed
+			state.mu.Unlock()
+
+			writeJSON(w, state.projectsJSON(false))
+			return
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/app/rest/agentPools/name:%s", state.poolName):
+			if r.URL.RawQuery != testPoolFieldsQuery {
+				http.Error(w, fmt.Sprintf("unexpected pool query: %s", r.URL.RawQuery), http.StatusBadRequest)
+				return
+			}
+			writeJSON(w, models.PoolJson{Name: state.poolName, Id: &state.poolID, Projects: state.projectsJSON(true)})
+			return
+		case r.Method == http.MethodDelete && r.URL.Path == fmt.Sprintf("/app/rest/agentPools/id:%d", state.poolID):
+			w.WriteHeader(http.StatusOK)
+			return
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery), http.StatusNotFound)
+			return
+		}
+	}))
+}
+
+func (s *fakePoolServerState) projectsJSON(includeVirtual bool) *models.ProjectsJson {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	projects := make([]models.ProjectJson, 0, len(s.managedProjects)+len(s.virtualProjects))
+	for _, id := range s.managedProjects {
+		projectID := id
+		projects = append(projects, models.ProjectJson{Name: id, Id: &projectID})
+	}
+	if includeVirtual {
+		for _, id := range s.virtualProjects {
+			projectID := id
+			projects = append(projects, models.ProjectJson{Name: id, Id: &projectID, Virtual: true})
+		}
+	}
+
+	return &models.ProjectsJson{Project: projects}
+}
+
+func decodeJSONBody(r *http.Request, target any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, target)
+}
+
+func writeJSON(w http.ResponseWriter, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func poolProviderConfig() string {
+	return providerConfig
+}
+
+func testCheckProjects(resourceName string, want []string, unwanted []string) resource.TestCheckFunc {
+	wantSet := make(map[string]struct{}, len(want))
+	for _, item := range want {
+		wantSet[item] = struct{}{}
+	}
+	unwantedSet := make(map[string]struct{}, len(unwanted))
+	for _, item := range unwanted {
+		unwantedSet[item] = struct{}{}
+	}
+
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		got := map[string]struct{}{}
+		for key, value := range rs.Primary.Attributes {
+			if strings.HasPrefix(key, "projects.") && key != "projects.#" {
+				got[value] = struct{}{}
+			}
+		}
+
+		if len(got) != len(wantSet) {
+			return fmt.Errorf("unexpected projects length: got %d (%v), want %d (%v)", len(got), got, len(wantSet), want)
+		}
+		for item := range wantSet {
+			if _, ok := got[item]; !ok {
+				return fmt.Errorf("expected project %q missing from state: %v", item, got)
+			}
+		}
+		for item := range unwantedSet {
+			if _, ok := got[item]; ok {
+				return fmt.Errorf("unexpected virtual project %q found in state: %v", item, got)
+			}
+		}
+
+		return nil
+	}
+}
+
+func TestAccPoolResource_virtualProjectsNoDrift(t *testing.T) {
+	virtualProjects := []string{
+		"Gradle_Master_Check_Quick_2_bucket1_virtual",
+		"Gradle_Release7x_Check_Stage_PullRequestFeedback_X",
+	}
+	server := newFakePoolServer(t, "demo-pool", nil, virtualProjects)
+	defer server.Close()
+	t.Setenv("TEAMCITY_HOST", server.URL)
+	t.Setenv("TEAMCITY_TOKEN", "test-token")
+
+	cfg := poolProviderConfig() + `
+resource "teamcity_pool" "test" {
+  name     = "demo-pool"
+  projects = ["Managed_A", "Managed_B"]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("teamcity_pool.test", "name", "demo-pool"),
+					resource.TestCheckResourceAttr("teamcity_pool.test", "projects.#", "2"),
+					testCheckProjects("teamcity_pool.test", []string{"Managed_A", "Managed_B"}, virtualProjects),
+				),
+			},
+			{
+				Config: cfg,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+func TestAccPoolDataSource_virtualProjectsFiltered(t *testing.T) {
+	virtualProjects := []string{
+		"Gradle_Master_Check_Quick_2_bucket1_virtual",
+		"Gradle_Release7x_Check_Stage_PullRequestFeedback_X",
+	}
+	server := newFakePoolServer(t, "demo-pool", []string{"Managed_A", "Managed_B"}, virtualProjects)
+	defer server.Close()
+	t.Setenv("TEAMCITY_HOST", server.URL)
+	t.Setenv("TEAMCITY_TOKEN", "test-token")
+
+	cfg := poolProviderConfig() + `
+data "teamcity_pool" "test" {
+  name = "demo-pool"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.teamcity_pool.test", "name", "demo-pool"),
+					resource.TestCheckResourceAttr("data.teamcity_pool.test", "projects.#", "2"),
+					testCheckProjects("data.teamcity_pool.test", []string{"Managed_A", "Managed_B"}, virtualProjects),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

The `teamcity_pool` resource (and `teamcity_pool` data source) copies **every** project returned by `GET /app/rest/agentPools/name:<name>` into Terraform state. That response includes **virtual projects** — auto-generated projects (e.g. created by the [parallel tests](https://www.jetbrains.com/help/teamcity/parallel-tests.html) feature) that TeamCity assigns to the pool by **parent-project inheritance**, not by the user.

Because these inherited projects are never present in the user's `projects` configuration, every `terraform plan` produces drift that tries to remove them, e.g.:

```
  ~ resource "teamcity_pool" "managed" {
        name     = "GBT-Linux-EC2"
      ~ projects = [
          - "Gradle_Master_Check_ConfigCache_38_bucket1_virtual",
          - "Gradle_Master_Check_ConfigCache_38_bucket2_virtual",
          - "Gradle_Master_Check_DocsTest_Windows_virtual",
          ... ~100 more ...
        ]
    }
```

Applying does not help: the virtual projects are regenerated and re-inherited when builds run, so the diff comes back on the next plan. On a real pool this was ~100 of ~320 reported members.

## Fix

TeamCity exposes a `virtual` boolean attribute on each project. This PR:

1. Adds `Virtual` to the project model.
2. Requests the `virtual` attribute in `GetPool` via an explicit `fields` query (it is **not** part of the default field set), re-listing the scalar pool fields so they are preserved.
3. Skips any project flagged `virtual` when building Terraform state, in both the resource (`getProjectsAttrValue`) and the data source.

Filtering on the server's `virtual` flag is more robust than matching the `_virtual` name suffix: it also correctly excludes virtual projects whose IDs do **not** end in `_virtual` (e.g. composite "stage" virtual projects), with no false positives.

## Testing

- `go build ./...` and existing `client` / `teamcity` package tests pass.
- Added `TestGetProjectsAttrValue_SkipsVirtual` covering the filtering, including a non-`_virtual`-suffixed virtual ID.
- Verified the `virtual` attribute and the `fields` query against a live TeamCity 2026.1 server: the default pool response omits `virtual`, while `fields=...,projects(project(id,name,virtual))` returns it correctly.
