### PR TITLE
test(client): cover group key generation in NewGroup

### DIFF
--- a/client/group_test.go
+++ b/client/group_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"terraform-provider-teamcity/models"
@@ -77,6 +78,71 @@ func TestGroup(t *testing.T) {
 
 				if actual.Description != "A new group" {
 					t.Fatalf("expected description 'A new group', got '%s'", actual.Description)
+				}
+			},
+		},
+		{
+			name: "test-new-group-generates-key-from-name",
+			test: func(t *testing.T) {
+				var sentBody []byte
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					sentBody, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"key":"MY_TESTGROUP_2","name":"My Test-Group 2!"}`))
+				}))
+				defer server.Close()
+
+				httpClient := NewClient(server.URL, "token", "", "", 12)
+
+				// No key supplied, so it has to be derived from the name:
+				// spaces become underscores, letters are upper-cased, digits are
+				// kept and anything else is dropped.
+				actual, err := httpClient.NewGroup(models.GroupJson{Name: "My Test-Group 2!"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var sent models.GroupJson
+				if err := json.Unmarshal(sentBody, &sent); err != nil {
+					t.Fatal(err)
+				}
+				if sent.Key != "MY_TESTGROUP_2" {
+					t.Fatalf("expected generated key 'MY_TESTGROUP_2' to be sent, got '%s'", sent.Key)
+				}
+				if sent.Name != "My Test-Group 2!" {
+					t.Fatalf("expected name to be sent unchanged, got '%s'", sent.Name)
+				}
+				if actual.Key != "MY_TESTGROUP_2" {
+					t.Fatalf("expected returned key 'MY_TESTGROUP_2', got '%s'", actual.Key)
+				}
+			},
+		},
+		{
+			name: "test-new-group-keeps-explicit-key",
+			test: func(t *testing.T) {
+				var sentBody []byte
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					sentBody, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"key":"custom_key","name":"My Test Group"}`))
+				}))
+				defer server.Close()
+
+				httpClient := NewClient(server.URL, "token", "", "", 12)
+
+				_, err := httpClient.NewGroup(models.GroupJson{Key: "custom_key", Name: "My Test Group"})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var sent models.GroupJson
+				if err := json.Unmarshal(sentBody, &sent); err != nil {
+					t.Fatal(err)
+				}
+				if sent.Key != "custom_key" {
+					t.Fatalf("expected explicit key 'custom_key' to be preserved, got '%s'", sent.Key)
 				}
 			},
 		},


### PR DESCRIPTION
## What

`client.generateKey` had **0% statement coverage**, and so did the `NewGroup` branch that calls it. Every existing test in `TestGroup` passed an explicit `Key`, so the auto-derivation path — the one users hit whenever they declare a `teamcity_group` without a key — was never exercised.

Per `.junie/guidelines.md` ("Add/maintain unit tests under `client/*_test.go` for client behavior"), this lives as a client unit test.

## Changes

Two new cases in `TestGroup` (`client/group_test.go`):

- **`test-new-group-generates-key-from-name`** — creates a group with no key and asserts on the JSON payload *actually sent to the server*, rather than on the helper in isolation. The name `"My Test-Group 2!"` pins all three mapping rules in one scenario:
  - whitespace → `_`
  - letters → upper-cased
  - digits → kept
  - everything else (`-`, `!`) → dropped

  …yielding `MY_TESTGROUP_2`. Note this documents that `-` is *dropped*, not converted, so hyphenated words are merged — worth having pinned either way.
- **`test-new-group-keeps-explicit-key`** — guards the other side of the branch: an explicitly supplied key is passed through untouched.

## Verification

**Ran and passing:**
- `go test -count=1 ./client/...` — passes.
- `go vet ./...` and `go build ./...` — clean.
- `generateKey` coverage **0% → 100%**; `NewGroup` **70% → 80%**; `client` package total 25.8% → 26.4%.
- Mutation-checked: flipping `unicode.ToUpper` to `unicode.ToLower` in `generateKey` fails the new test, confirming the assertion is load-bearing rather than vacuous.

**Not run — needs a reviewer with a working environment:**
- The `teamcity/` acceptance suite (32 tests) could **not** be executed here. I started the TeamCity server from `docker-compose.yml` and it reached `healthCheck/ready`, but `TF_ACC=1 go test ./teamcity` then failed at `failed to find or install Terraform CLI ... checkpoint-api.hashicorp.com: Forbidden` — this sandbox has no Terraform CLI and no network access to `releases.hashicorp.com` to install one. Please confirm CI runs them green.

Note that without `TF_ACC=1` those 32 tests silently **skip** rather than fail, so a bare `go test ./...` reports `ok` for the `teamcity` package while testing nothing.

## Scope

This PR is **test-only** — no production code is touched. The guidelines' mandatory-acceptance-test rule ("every new fix or feature MUST include acceptance tests") doesn't apply, as there is no behavior change to cover; the two cases pin existing behavior. No new resource, so no `tfplugindocs` regeneration is needed either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)