### PR TITLE
fix(docker-compose): normalize testdata permissions before server starts

### DIFF
--- a/docker-compose-with-agent.yml
+++ b/docker-compose-with-agent.yml
@@ -1,6 +1,22 @@
 services:
+  # The teamcity-server-local image runs as a fixed non-root uid, which commonly
+  # differs from the uid that owns ./testdata on the host after a fresh checkout.
+  # Without this, the server can't write into the bind-mounted directory and gets
+  # stuck waiting for interactive startup confirmation instead of reading
+  # teamcity.properties. Reset the host permissions before the server starts.
+  init-testdata-permissions:
+    image: alpine:3.20
+    entrypoint: ["chmod", "-R", "a+rwX", "/testdata"]
+    volumes:
+      - type: bind
+        source: "./testdata"
+        target: "/testdata"
+
   teamcity-server-local:
     image: jetbrains/teamcity-server:2025.11-linux-arm64
+    depends_on:
+      init-testdata-permissions:
+        condition: service_completed_successfully
     volumes:
       - type: bind
         source: "./testdata"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 services:
+  # The teamcity-server-local image runs as a fixed non-root uid, which commonly
+  # differs from the uid that owns ./testdata on the host after a fresh checkout.
+  # Without this, the server can't write into the bind-mounted directory and gets
+  # stuck waiting for interactive startup confirmation instead of reading
+  # teamcity.properties. Reset the host permissions before the server starts.
+  init-testdata-permissions:
+    image: alpine:3.20
+    entrypoint: ["chmod", "-R", "a+rwX", "/testdata"]
+    volumes:
+      - type: bind
+        source: "./testdata"
+        target: "/testdata"
+
   teamcity-server-local:
     image: jetbrains/teamcity-server:2026.1.2
+    depends_on:
+      init-testdata-permissions:
+        condition: service_completed_successfully
     volumes:
       - type: bind
         source: "./testdata"


### PR DESCRIPTION
## Problem

`docker-compose.yml` bind-mounts `./testdata` into the TeamCity server container so it can pick up `teamcity.properties` (the disposable superuser token / auto-accept-license config referenced in `CONTRIBUTING.md` and `.junie/guidelines.md`).

The server image runs as a fixed non-root uid. If the host checkout is owned by a different uid — which is the normal case for a fresh `git clone` in most dev/CI containers, not an edge case — the server can't write into the bind-mounted directory. It then silently falls back to interactive startup confirmation instead of applying `teamcity.properties`, and `docker compose up --wait` just times out on the healthcheck with no actionable error in the default log output (there's a single easy-to-miss `WARN ... Unable to create startup configuration file '/testdata/teamcity.properties'` line).

I hit this directly while trying to run the acceptance suite from `.junie/guidelines.md`: `podman compose up -d --wait --wait-timeout 1000` (my case: `docker compose`) never became healthy until I manually `chmod`'d `./testdata`.

## Fix

Add an `init-testdata-permissions` service (small `alpine` container) that `chmod -R a+rwX ./testdata` before `teamcity-server-local` starts, wired with `depends_on: condition: service_completed_successfully`. This makes `docker compose up` self-sufficient regardless of the host checkout's ownership — no manual steps, no docs update needed for contributors.

Applied to both contributor-facing files referenced by `.junie/guidelines.md`:
- `docker-compose.yml`
- `docker-compose-with-agent.yml`

`docker-compose-internal.yml` is intentionally left untouched — it targets a private JetBrains registry image and isn't referenced by `CONTRIBUTING.md` or `.junie/guidelines.md`, so I have no visibility into how it's actually invoked internally and didn't want to guess.

## Verification

- Reproduced the original failure organically: this sandbox's checkout uid didn't match the container's, and `docker compose up --wait` hung until I chmod'd `testdata` by hand.
- With the fix and pristine (fresh-checkout-equivalent) permissions on `./testdata`, `docker compose up -d --wait --wait-timeout 400` reached `Healthy` on the first try, no manual intervention.
- Confirmed the server is actually usable afterward: `healthCheck/ready` → `200`, and an authenticated REST call (`curl -u ":token123" http://localhost:8111/app/rest/server`) → `200`.
- `docker compose config` and `docker compose -f docker-compose-with-agent.yml config` both parse cleanly. `docker-compose-with-agent.yml`'s TeamCity images are `arm64`-only, so I couldn't boot the full stack on this `amd64` sandbox, but it carries the identical, architecture-independent init step.
- Full teardown (`docker compose down -v`) after each run; `./testdata` permissions and ownership restored to their pristine post-checkout state; no stray containers or files left behind. `git status` is clean apart from the two intended file changes.

## Scope

Config-only change, no Go code touched. Not a "new fix or feature" against provider behavior, so the acceptance-testing guideline in `.junie/guidelines.md` doesn't apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)