### PR TITLE
docs: point AI coding agents at CONTRIBUTING.md and .junie/guidelines.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repo guidelines
+
+Before making changes, read:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local dev setup, running the provider, running tests.
+- [.junie/guidelines.md](.junie/guidelines.md) — architecture and conventions for `client/`, `models/`, `teamcity/`, plus testing requirements.
+
+These are the source of truth for this project; don't skip them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Repo guidelines
+
+Before making changes, read:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local dev setup, running the provider, running tests.
+- [.junie/guidelines.md](.junie/guidelines.md) — architecture and conventions for `client/`, `models/`, `teamcity/`, plus testing requirements.
+
+These are the source of truth for this project; don't skip them.


### PR DESCRIPTION
## Why

While working on this repo I skipped `CONTRIBUTING.md`'s pointer to `.junie/guidelines.md` and missed the project's actual conventions (client/models/teamcity layering, deprecated helpers, mandatory acceptance tests, etc.) until asked to go check. Nothing at the repo root told an agent to read those files before making changes — they only surface if you happen to open `CONTRIBUTING.md` in full.

## Change

Add two minimal, identical files at the repo root:

- `CLAUDE.md` — read by Claude Code.
- `AGENTS.md` — the emerging cross-tool convention (Codex CLI, others).

Both just point at `CONTRIBUTING.md` and `.junie/guidelines.md` as the source of truth. No content is duplicated — deliberately small so it doesn't drift out of sync with the real docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)