### PR TITLE
fix(vcs-root): always set checkout_rules from server response on create

### DIFF
--- a/teamcity/build_configuration_vcs_root_resource.go
+++ b/teamcity/build_configuration_vcs_root_resource.go
@@ -97,9 +97,7 @@ func (r *bcVcsRootResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	plan.ID = types.StringValue(fmt.Sprintf("%s/%s", buildTypeId, vcsRootId))
-	if actual.CheckoutRules != "" {
-		plan.CheckoutRules = types.StringValue(actual.CheckoutRules)
-	}
+	plan.CheckoutRules = types.StringValue(actual.CheckoutRules)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/teamcity/build_configuration_vcs_root_test.go
+++ b/teamcity/build_configuration_vcs_root_test.go
@@ -36,11 +36,43 @@ resource "teamcity_build_configuration" "bc" {
 resource "teamcity_build_configuration_vcs_root" "attach" {
   build_configuration_id = teamcity_build_configuration.bc.id
   vcs_root_id            = teamcity_vcsroot.v.id
-  checkout_rules         = "+:.=>somewhere"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("teamcity_build_configuration_vcs_root.attach", "vcs_root_id", "my_vcs_root"),
+					resource.TestCheckResourceAttr("teamcity_build_configuration_vcs_root.attach", "checkout_rules", ""),
+				),
+			},
+			{
+				Config: providerConfig + `
+resource "teamcity_project" "p" {
+  name = "VCS Project"
+  id   = "vcs_project"
+}
+
+resource "teamcity_vcsroot" "v" {
+  name       = "My VCS Root"
+  id         = "my_vcs_root"
+  project_id = teamcity_project.p.id
+  git = {
+    url    = "https://github.com/jetbrains/teamcity"
+    branch = "refs/heads/master"
+  }
+}
+
+resource "teamcity_build_configuration" "bc" {
+  project_id = teamcity_project.p.id
+  name       = "VCS BC"
+  id         = "vcs_bc"
+}
+
+resource "teamcity_build_configuration_vcs_root" "attach" {
+  build_configuration_id = teamcity_build_configuration.bc.id
+  vcs_root_id            = teamcity_vcsroot.v.id
+  checkout_rules         = "+:.=>somewhere"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("teamcity_build_configuration_vcs_root.attach", "checkout_rules", "+:.=>somewhere"),
 				),
 			},


### PR DESCRIPTION
## Summary

`checkout_rules` on `teamcity_build_configuration_vcs_root` is `Optional + Computed` with no default. When it is omitted from the configuration, its planned value is **unknown**, not null — and `Create` only copied the server value into state when that value was non-empty:

```go
if actual.CheckoutRules != "" {
    plan.CheckoutRules = types.StringValue(actual.CheckoutRules)
}
```

TeamCity returns an empty string for an attachment with no checkout rules, so the guard skipped the assignment, the unknown survived into state, and the apply failed with the provider returning an unknown value after apply.

The fix assigns the server value unconditionally. An acceptance step that omits `checkout_rules` and asserts it settles to `""` is added, so the previously untested path is now covered.

## Note: this pattern appears elsewhere

The root cause is that an omitted `Optional + Computed` attribute is unknown rather than null, so `IsNull()` guards do not fire for it. The same shape exists in several other resources and is **not** addressed here:

- `teamcity_build_configuration_settings` — `build_number_counter`, `build_number_pattern`, and `artifact_rules` are each guarded by `!plan.X.IsNull()` in `Create`/`Update`. For an omitted attribute the guard passes and `ValueString()`/`ValueInt64()` yield `""`/`0`, so the provider writes those values to TeamCity (resetting the build number counter and clearing the pattern and artifact rules) before failing on the same unknown-in-state problem.
- `teamcity_build_configuration_step`, `_feature`, `_trigger`, `_snapshot_dependency`, and `_artifact_dependency` — all call `properties.ElementsAs(...)` behind a `!IsNull()` guard. On an unknown map that errors with "Received unknown value, however the target type cannot handle unknown values", surfaced to users as "This is always an error in the provider."
- `teamcity_user_role_assignment` — the "Either 'user_id' or 'username' must be specified" validation cannot fire, because `user_id` is unknown rather than null when omitted.

`teamcity_cloud_profile` already handles this correctly (`if value.IsNull() || value.IsUnknown()`) and is a good reference for fixing the rest. Happy to follow up with a separate PR if that is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
